### PR TITLE
feat(#10, #11): keyword matching engine and ad ranker

### DIFF
--- a/src/matching/index.ts
+++ b/src/matching/index.ts
@@ -1,2 +1,4 @@
-// Matching pipeline: keyword-matcher → ranker — TODO(#10, #11)
-export {};
+export { matchAds, extractKeywords } from "./keyword-matcher.js";
+export type { SearchQuery, AdCandidate, MatchResult } from "./keyword-matcher.js";
+export { rankAds } from "./ranker.js";
+export type { RankedAd } from "./ranker.js";

--- a/src/matching/keyword-matcher.ts
+++ b/src/matching/keyword-matcher.ts
@@ -1,2 +1,138 @@
-// Keyword matching engine — TODO(#10)
-export {};
+export interface SearchQuery {
+  query?: string;
+  keywords?: string[];
+  category?: string;
+  geo?: string;
+  language?: string;
+}
+
+export interface AdCandidate {
+  id: string;
+  campaign_id: string;
+  creative_text: string;
+  link_url: string;
+  keywords: string[];
+  categories: string[];
+  geo: string;
+  language: string;
+  quality_score: number;
+  bid_amount: number;
+  advertiser_name: string;
+}
+
+export interface MatchResult {
+  ad: AdCandidate;
+  relevance_score: number;
+  match_details: {
+    exact_keyword_matches: string[];
+    partial_keyword_matches: string[];
+    category_match: boolean;
+    geo_match: boolean;
+    language_match: boolean;
+  };
+}
+
+const STOPWORDS = new Set([
+  "a", "an", "the", "is", "it", "of", "in", "to", "for", "on", "with",
+  "at", "by", "from", "this", "that", "and", "or", "but", "not", "are",
+  "was", "were", "be", "been", "being", "have", "has", "had", "do", "does",
+  "did", "will", "would", "could", "should", "may", "might", "can",
+  "i", "me", "my", "we", "our", "you", "your", "he", "she", "they",
+  "what", "which", "who", "where", "when", "how", "why",
+  "want", "need", "looking", "find", "get", "buy", "best", "good",
+  "un", "una", "el", "la", "los", "las", "de", "en", "por", "para",
+  "con", "que", "es", "son", "del", "al", "como", "más", "muy",
+  "quiero", "necesito", "busco", "comprar", "mejor", "bueno",
+]);
+
+export function extractKeywords(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s]/g, " ")
+    .split(/\s+/)
+    .filter((word) => word.length > 1 && !STOPWORDS.has(word));
+}
+
+function normalize(s: string): string {
+  return s.toLowerCase().trim();
+}
+
+export function matchAds(query: SearchQuery, ads: AdCandidate[]): MatchResult[] {
+  const queryKeywords: string[] = [];
+
+  if (query.keywords) {
+    queryKeywords.push(...query.keywords.map(normalize));
+  }
+  if (query.query) {
+    queryKeywords.push(...extractKeywords(query.query));
+  }
+
+  if (queryKeywords.length === 0 && !query.category) {
+    return [];
+  }
+
+  // Deduplicate
+  const uniqueKeywords = [...new Set(queryKeywords)];
+
+  const results: MatchResult[] = [];
+
+  for (const ad of ads) {
+    const adKeywords = ad.keywords.map(normalize);
+    const adCategories = ad.categories.map(normalize);
+
+    const exact_keyword_matches: string[] = [];
+    const partial_keyword_matches: string[] = [];
+
+    for (const qk of uniqueKeywords) {
+      for (const ak of adKeywords) {
+        if (qk === ak) {
+          if (!exact_keyword_matches.includes(ak)) {
+            exact_keyword_matches.push(ak);
+          }
+        } else if (ak.includes(qk) || qk.includes(ak)) {
+          if (!partial_keyword_matches.includes(ak)) {
+            partial_keyword_matches.push(ak);
+          }
+        }
+      }
+    }
+
+    const category_match = query.category
+      ? adCategories.includes(normalize(query.category))
+      : false;
+
+    const geo_match =
+      !query.geo || ad.geo === "ALL" || normalize(ad.geo) === normalize(query.geo);
+
+    const language_match =
+      !query.language || normalize(ad.language) === normalize(query.language);
+
+    // Calculate relevance score
+    let score = 0;
+    score += exact_keyword_matches.length * 0.3;
+    score += partial_keyword_matches.length * 0.15;
+    if (category_match) score += 0.2;
+    if (geo_match) score += 0.1;
+    if (language_match) score += 0.05;
+
+    // Normalize to max 1.0
+    score = Math.min(score, 1.0);
+
+    // Only include if there's some relevance
+    if (score > 0.05) {
+      results.push({
+        ad,
+        relevance_score: Math.round(score * 100) / 100,
+        match_details: {
+          exact_keyword_matches,
+          partial_keyword_matches,
+          category_match,
+          geo_match,
+          language_match,
+        },
+      });
+    }
+  }
+
+  return results;
+}

--- a/src/matching/ranker.ts
+++ b/src/matching/ranker.ts
@@ -1,2 +1,38 @@
-// Ad ranking algorithm — TODO(#11)
-export {};
+import type { MatchResult } from "./keyword-matcher.js";
+
+export interface RankedAd {
+  ad_id: string;
+  advertiser_name: string;
+  creative_text: string;
+  link_url: string;
+  relevance_score: number;
+  disclosure: "sponsored";
+}
+
+const MIN_RELEVANCE_THRESHOLD = 0.1;
+
+export function rankAds(matches: MatchResult[], maxResults: number = 3): RankedAd[] {
+  if (matches.length === 0) return [];
+
+  const maxBid = Math.max(...matches.map((m) => m.ad.bid_amount));
+
+  const scored = matches
+    .filter((m) => m.relevance_score >= MIN_RELEVANCE_THRESHOLD)
+    .map((m) => {
+      const normalizedBid = maxBid > 0 ? m.ad.bid_amount / maxBid : 1;
+      const finalScore =
+        m.relevance_score * normalizedBid * m.ad.quality_score;
+      return { match: m, score: finalScore };
+    })
+    .sort((a, b) => b.score - a.score)
+    .slice(0, maxResults);
+
+  return scored.map(({ match }) => ({
+    ad_id: match.ad.id,
+    advertiser_name: match.ad.advertiser_name,
+    creative_text: match.ad.creative_text,
+    link_url: match.ad.link_url,
+    relevance_score: match.relevance_score,
+    disclosure: "sponsored" as const,
+  }));
+}


### PR DESCRIPTION
## Summary
- Implements keyword matching engine (`keyword-matcher.ts`) with exact/partial keyword matching, category/geo/language filtering, and relevance scoring
- Implements ad ranking algorithm (`ranker.ts`) that combines relevance score, bid amount, and quality score to rank matched ads
- Exports all types and functions from `matching/index.ts` barrel file

## Details
- Stopword filtering for both English and Spanish queries
- Relevance scoring: exact keyword match (0.3), partial match (0.15), category (0.2), geo (0.1), language (0.05)
- Ranker uses formula: `relevance * normalizedBid * qualityScore` to produce final ranking
- All ads include `disclosure: "sponsored"` for transparency

## Test plan
- [ ] Verify exact keyword matching returns correct scores
- [ ] Verify partial keyword matching works (substring)
- [ ] Verify geo/language/category filters
- [ ] Verify ranker sorts by combined score correctly
- [ ] Verify `maxResults` parameter limits output

Closes #10
Closes #11