### PR TITLE
feat(#13): API key authentication middleware

### DIFF
--- a/src/auth/middleware.ts
+++ b/src/auth/middleware.ts
@@ -1,2 +1,112 @@
-// API key authentication — TODO(#13)
-export {};
+// ──────────────────────────────────────────────────────────────────────────────
+// API key authentication middleware (#13)
+// ──────────────────────────────────────────────────────────────────────────────
+
+import crypto from 'node:crypto';
+import type Database from 'better-sqlite3';
+import { createApiKey, findApiKey } from '../db/index.js';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface AuthContext {
+  entity_type: 'advertiser' | 'developer';
+  entity_id: string;
+  key_id: string;
+}
+
+export class AuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AuthError';
+  }
+}
+
+// ─── Key Generation ─────────────────────────────────────────────────────────
+
+const KEY_PREFIX = {
+  advertiser: 'aa_adv_',
+  developer: 'aa_dev_',
+} as const;
+
+/**
+ * Generate a new API key for an entity and store its hash in the DB.
+ * Returns the raw key (shown once, never stored).
+ */
+export function generateApiKey(
+  db: InstanceType<typeof Database>,
+  entity_type: 'advertiser' | 'developer',
+  entity_id: string,
+): string {
+  const random = crypto.randomBytes(32).toString('hex');
+  const rawKey = `${KEY_PREFIX[entity_type]}${random}`;
+  const keyHash = hashKey(rawKey);
+
+  createApiKey(db, { key_hash: keyHash, entity_type, entity_id });
+
+  return rawKey;
+}
+
+// ─── Key Hashing ────────────────────────────────────────────────────────────
+
+export function hashKey(rawKey: string): string {
+  return crypto.createHash('sha256').update(rawKey).digest('hex');
+}
+
+// ─── Key Parsing ────────────────────────────────────────────────────────────
+
+function parseKeyPrefix(rawKey: string): 'advertiser' | 'developer' | null {
+  if (rawKey.startsWith(KEY_PREFIX.advertiser)) return 'advertiser';
+  if (rawKey.startsWith(KEY_PREFIX.developer)) return 'developer';
+  return null;
+}
+
+// ─── Authentication ─────────────────────────────────────────────────────────
+
+/**
+ * Authenticate a raw API key against the database.
+ * Returns an AuthContext on success, throws AuthError on failure.
+ */
+export function authenticate(
+  db: InstanceType<typeof Database>,
+  rawKey: string,
+): AuthContext {
+  if (!rawKey) {
+    throw new AuthError('API key is required');
+  }
+
+  const prefixType = parseKeyPrefix(rawKey);
+  if (!prefixType) {
+    throw new AuthError('Invalid API key format');
+  }
+
+  const keyHash = hashKey(rawKey);
+  const apiKey = findApiKey(db, keyHash);
+
+  if (!apiKey) {
+    throw new AuthError('Invalid API key');
+  }
+
+  // Sanity check: prefix should match stored entity_type
+  if (apiKey.entity_type !== prefixType) {
+    throw new AuthError('API key type mismatch');
+  }
+
+  return {
+    entity_type: apiKey.entity_type,
+    entity_id: apiKey.entity_id,
+    key_id: apiKey.id,
+  };
+}
+
+// ─── HTTP Header Extraction ─────────────────────────────────────────────────
+
+/**
+ * Extract API key from an HTTP Authorization header.
+ * Expects: `Bearer <key>`
+ */
+export function extractKeyFromHeader(authHeader: string | undefined): string | null {
+  if (!authHeader) return null;
+  const parts = authHeader.split(' ');
+  if (parts.length !== 2 || parts[0] !== 'Bearer') return null;
+  return parts[1];
+}

--- a/tests/auth/middleware.test.ts
+++ b/tests/auth/middleware.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { initDatabase } from '../../src/db/index.js';
+import { createAdvertiser, createDeveloper } from '../../src/db/index.js';
+import {
+  generateApiKey,
+  authenticate,
+  hashKey,
+  extractKeyFromHeader,
+  AuthError,
+} from '../../src/auth/middleware.js';
+
+describe('Auth Middleware', () => {
+  let db: ReturnType<typeof initDatabase>;
+  let advertiserId: string;
+  let developerId: string;
+
+  beforeEach(() => {
+    db = initDatabase(':memory:');
+    const adv = createAdvertiser(db, { name: 'Test Advertiser' });
+    const dev = createDeveloper(db, { name: 'Test Developer' });
+    advertiserId = adv.id;
+    developerId = dev.id;
+  });
+
+  describe('generateApiKey', () => {
+    it('generates advertiser key with correct prefix', () => {
+      const key = generateApiKey(db, 'advertiser', advertiserId);
+      expect(key).toMatch(/^aa_adv_[a-f0-9]{64}$/);
+    });
+
+    it('generates developer key with correct prefix', () => {
+      const key = generateApiKey(db, 'developer', developerId);
+      expect(key).toMatch(/^aa_dev_[a-f0-9]{64}$/);
+    });
+
+    it('generates unique keys each time', () => {
+      const key1 = generateApiKey(db, 'advertiser', advertiserId);
+      const key2 = generateApiKey(db, 'advertiser', advertiserId);
+      expect(key1).not.toBe(key2);
+    });
+
+    it('stores the key hash in the database', () => {
+      const key = generateApiKey(db, 'advertiser', advertiserId);
+      const keyHash = hashKey(key);
+      const row = db.prepare('SELECT * FROM api_keys WHERE key_hash = ?').get(keyHash);
+      expect(row).toBeDefined();
+    });
+  });
+
+  describe('authenticate', () => {
+    it('authenticates a valid advertiser key', () => {
+      const key = generateApiKey(db, 'advertiser', advertiserId);
+      const auth = authenticate(db, key);
+      expect(auth.entity_type).toBe('advertiser');
+      expect(auth.entity_id).toBe(advertiserId);
+      expect(auth.key_id).toBeDefined();
+    });
+
+    it('authenticates a valid developer key', () => {
+      const key = generateApiKey(db, 'developer', developerId);
+      const auth = authenticate(db, key);
+      expect(auth.entity_type).toBe('developer');
+      expect(auth.entity_id).toBe(developerId);
+    });
+
+    it('throws AuthError for empty key', () => {
+      expect(() => authenticate(db, '')).toThrow(AuthError);
+      expect(() => authenticate(db, '')).toThrow('API key is required');
+    });
+
+    it('throws AuthError for invalid prefix', () => {
+      expect(() => authenticate(db, 'invalid_prefix_key')).toThrow(AuthError);
+      expect(() => authenticate(db, 'invalid_prefix_key')).toThrow('Invalid API key format');
+    });
+
+    it('throws AuthError for unknown key', () => {
+      expect(() => authenticate(db, 'aa_adv_' + 'a'.repeat(64))).toThrow(AuthError);
+      expect(() => authenticate(db, 'aa_adv_' + 'a'.repeat(64))).toThrow('Invalid API key');
+    });
+  });
+
+  describe('hashKey', () => {
+    it('produces consistent SHA-256 hash', () => {
+      const key = 'aa_adv_test123';
+      expect(hashKey(key)).toBe(hashKey(key));
+    });
+
+    it('produces different hashes for different keys', () => {
+      expect(hashKey('aa_adv_key1')).not.toBe(hashKey('aa_adv_key2'));
+    });
+
+    it('produces a 64-char hex string', () => {
+      expect(hashKey('test')).toMatch(/^[a-f0-9]{64}$/);
+    });
+  });
+
+  describe('extractKeyFromHeader', () => {
+    it('extracts key from valid Bearer header', () => {
+      expect(extractKeyFromHeader('Bearer aa_adv_test123')).toBe('aa_adv_test123');
+    });
+
+    it('returns null for missing header', () => {
+      expect(extractKeyFromHeader(undefined)).toBeNull();
+    });
+
+    it('returns null for non-Bearer scheme', () => {
+      expect(extractKeyFromHeader('Basic abc123')).toBeNull();
+    });
+
+    it('returns null for malformed header', () => {
+      expect(extractKeyFromHeader('Bearer')).toBeNull();
+      expect(extractKeyFromHeader('Bearer a b c')).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `src/auth/middleware.ts` with `generateApiKey`, `authenticate`, `hashKey`, `extractKeyFromHeader`
- Key format: `aa_adv_<random64hex>` (advertiser) / `aa_dev_<random64hex>` (developer), stored as SHA-256 hashes
- Integrates auth into `server.ts`: session-based auth map for stdio (`--api-key` / env var) and HTTP (`Authorization: Bearer`)
- Advertiser tools enforce ownership; `report_event` uses real developer ID; `search_ads`/`get_ad_guidelines` remain public
- 16 unit tests, all passing

## Test plan
- [x] `npx vitest run tests/auth/middleware.test.ts` — 16 tests pass
- [x] `npx tsc --noEmit` — clean compile

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)