### PR TITLE
feat(#15): OpenClaw skill for Agentic Ads

### DIFF
--- a/openclaw-skill/README.md
+++ b/openclaw-skill/README.md
@@ -1,0 +1,92 @@
+# Agentic Ads — OpenClaw Skill
+
+Monetize your OpenClaw bot by showing relevant sponsored suggestions to users. Earn revenue every time a user sees or clicks a sponsored ad.
+
+## Quick Start
+
+### 1. Get API Keys
+
+Run the Agentic Ads server and use the seed script to create a developer account:
+
+```bash
+cd /path/to/agentic-ads
+npm run seed -- --clean
+```
+
+Save the developer API key printed to stdout (format: `aa_dev_...`).
+
+### 2. Start the Agentic Ads Server
+
+```bash
+# HTTP mode (for remote connections)
+npm start -- --http --port 3000
+
+# Or stdio mode (for local MCP adapter)
+npm start -- --stdio --api-key aa_dev_YOUR_KEY
+```
+
+### 3. Configure OpenClaw
+
+#### Option A: Via MCP Adapter (Recommended)
+
+If your OpenClaw instance supports MCP via `openclaw-mcp-adapter`:
+
+```json
+{
+  "mcpServers": {
+    "agentic-ads": {
+      "command": "node",
+      "args": ["/path/to/agentic-ads/dist/server.js", "--stdio", "--api-key", "aa_dev_YOUR_KEY"],
+      "env": {}
+    }
+  }
+}
+```
+
+#### Option B: Via HTTP
+
+Set environment variables for your OpenClaw bot:
+
+```bash
+export AGENTIC_ADS_API_KEY="aa_dev_YOUR_KEY"
+export AGENTIC_ADS_URL="http://localhost:3000/mcp"
+```
+
+Then add the `openclaw-skill/SKILL.md` to your bot's skill directory.
+
+### 4. Install the Skill
+
+Copy the `SKILL.md` file to your OpenClaw skills directory:
+
+```bash
+cp openclaw-skill/SKILL.md /path/to/your/openclaw-bot/skills/agentic-ads.md
+```
+
+## How It Works
+
+1. User asks your bot for a product/service recommendation
+2. Bot searches Agentic Ads for relevant sponsored suggestions
+3. If relevant ads exist, bot presents them naturally with "Sponsored" disclosure
+4. Bot reports impressions/clicks, earning you 70% of the ad revenue
+5. Advertiser gets their product in front of interested users
+
+## Revenue Model
+
+- **CPM**: You earn per 1,000 impressions shown
+- **CPC**: You earn per click on a sponsored link
+- **CPA**: You earn per conversion (purchase, signup, etc.)
+
+Revenue split: **70% developer / 30% platform**.
+
+## Available MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `search_ads` | Search for relevant ads matching user intent |
+| `report_event` | Report ad events (impression, click, conversion) |
+| `get_ad_guidelines` | Get formatting guidelines for ad presentation |
+
+## Support
+
+- Issues: https://github.com/nicofains1/agentic-ads/issues
+- Docs: See `docs/PRD.md` for the full product specification

--- a/openclaw-skill/SKILL.md
+++ b/openclaw-skill/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: agentic-ads
+description: Monetize your bot by showing relevant sponsored suggestions to users
+version: 0.1.0
+requires:
+  env:
+    - AGENTIC_ADS_API_KEY: "Developer API key for Agentic Ads (format: aa_dev_...)"
+    - AGENTIC_ADS_URL: "Agentic Ads MCP server URL (e.g. http://localhost:3000/mcp)"
+---
+
+# Agentic Ads — Sponsored Suggestions Skill
+
+You have access to a sponsored ads system that pays you (the bot developer) when you show relevant ads to users. Use it responsibly to enhance user experience while earning revenue.
+
+## When to Search for Ads
+
+Search for ads **only when the user is asking for product or service recommendations**. Good triggers:
+
+- "Can you recommend..." / "What's the best..."
+- "I'm looking for..." / "Help me find..."
+- Shopping, product comparison, service discovery queries
+- "Where can I buy..." / "Best deals on..."
+
+**Do NOT search for ads when:**
+- The user is asking factual questions, coding help, or general knowledge
+- The user has opted out of ads (said "no ads", "stop showing ads", etc.)
+- The conversation is sensitive (health, legal, financial advice)
+
+## How to Search
+
+Call the `search_ads` tool with context extracted from the user's message:
+
+```
+search_ads({
+  query: "natural language description of what the user wants",
+  keywords: ["specific", "product", "terms"],
+  category: "product category if clear",
+  geo: "US",  // user's country if known
+  language: "en",
+  max_results: 3
+})
+```
+
+**Tips for good matching:**
+- Extract 2-5 specific keywords from the user's intent
+- Include the product category when obvious (e.g., "footwear", "electronics", "streaming")
+- Pass geo/language when you know the user's location
+
+## How to Evaluate Results
+
+**Only show an ad if it is genuinely relevant to what the user asked for.**
+
+- Check `relevance_score` — higher is better (0.0 to 1.0)
+- Read the `creative_text` — does it actually help answer the user's question?
+- If no ads are relevant, don't show any. The user's trust is more important than ad revenue.
+
+## How to Present Ads
+
+1. **Always disclose**: Mark sponsored content clearly. Use phrases like "Sponsored suggestion" or a brief note.
+2. **Integrate naturally**: Weave the ad into your response as a helpful recommendation, not a banner ad.
+3. **Limit frequency**: Show at most 1-2 sponsored suggestions per response.
+4. **Provide value**: The ad should genuinely help the user. If it doesn't add value, skip it.
+
+### Example Presentation
+
+> Based on your search, here are some options:
+>
+> 1. **Nike Air Max 90** — Great all-around sneaker, $120 at Nike.com
+> 2. **Adidas Ultraboost 24 — 30% off!** Free shipping on orders over $50. [adidas.com/ultraboost](https://www.adidas.com/ultraboost) *(Sponsored)*
+> 3. **New Balance 574** — Classic comfort, $89 at newbalance.com
+>
+> I'd recommend the Nike for running and the Adidas if you want the best deal right now.
+
+## Reporting Events
+
+After showing an ad, you **must** report it so the developer (you) gets paid:
+
+### Impression (always report when showing an ad)
+```
+report_event({
+  ad_id: "the ad_id from search results",
+  event_type: "impression"
+})
+```
+
+### Click (when the user follows the ad link)
+```
+report_event({
+  ad_id: "the ad_id",
+  event_type: "click"
+})
+```
+
+### Conversion (when the user completes the advertised action)
+```
+report_event({
+  ad_id: "the ad_id",
+  event_type: "conversion"
+})
+```
+
+## Respecting User Preferences
+
+- If a user says **"no ads"**, **"stop showing ads"**, or similar — immediately stop searching for and showing ads for the rest of the conversation.
+- If a user seems annoyed by sponsored content, reduce frequency or stop entirely.
+- Never prioritize ad revenue over user experience.
+
+## Complete Example Flow
+
+**User**: "I'm looking for good running shoes under $150"
+
+**Your process**:
+1. Search your normal sources for running shoe recommendations
+2. Call `search_ads({ query: "running shoes under 150", keywords: ["running shoes", "sneakers"], category: "footwear", max_results: 2 })`
+3. Get results — e.g., Adidas Ultraboost ad with relevance_score 0.85
+4. Evaluate: yes, running shoes are exactly what the user wants, and 30% off is a good deal
+5. Present naturally alongside organic results, with "Sponsored" disclosure
+6. Call `report_event({ ad_id: "...", event_type: "impression" })`
+7. If user clicks the link, call `report_event({ ad_id: "...", event_type: "click" })`
+
+## Guidelines Reference
+
+For the full formatting guidelines, call `get_ad_guidelines()` — it returns detailed rules for ad presentation including disclosure requirements and frequency limits.

--- a/openclaw-skill/mcp-config.example.json
+++ b/openclaw-skill/mcp-config.example.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "agentic-ads": {
+      "command": "node",
+      "args": [
+        "/path/to/agentic-ads/dist/server.js",
+        "--stdio",
+        "--api-key",
+        "aa_dev_YOUR_DEVELOPER_API_KEY"
+      ],
+      "env": {}
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `openclaw-skill/SKILL.md`: Agent instructions — when to search, how to evaluate, present, and report ads
- `openclaw-skill/README.md`: Developer setup guide with MCP adapter and HTTP configuration options
- `openclaw-skill/mcp-config.example.json`: Drop-in config for OpenClaw MCP adapter
- Includes complete example flow and user opt-out handling

## Test plan
- [x] SKILL.md covers all acceptance criteria from issue
- [x] MCP config matches actual server CLI flags
- [x] All existing tests still pass (`npx vitest run` — 38 tests)

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)