### PR TITLE
test(#36): resolve 🟡 items — 255 tests, 1 🟡 remaining

### DIFF
--- a/bulloak.md
+++ b/bulloak.md
@@ -137,7 +137,7 @@ Consumer Onboarding
 │   └── Key format: aa_dev_<64 hex chars>                                      🟢 tests/auth/middleware.test.ts
 ├── Conectar al MCP
 │   ├── stdio: --api-key aa_dev_... → auth OK                                 🟢 tests/integration/mcp-stdio.test.ts
-│   ├── HTTP: Authorization: Bearer aa_dev_... → auth OK                       🟡 tests/integration/http-transport.test.ts (advKey tested; devKey implicit)
+│   ├── HTTP: Authorization: Bearer aa_dev_... → auth OK                       🟢 tests/integration/http-transport.test.ts
 │   └── Sin key → modo público (solo tools sin auth)                           🟢 tests/integration/http-transport.test.ts + stdio-auth.test.ts
 ├── Verificar acceso
 │   ├── Puede llamar: search_ads, report_event, get_ad_guidelines             🟢 tests/e2e.test.ts
@@ -198,7 +198,7 @@ search_ads
 │   └── MIN_RELEVANCE_THRESHOLD = 0.1: debajo se descarta                    🟢 tests/matching/ranker.test.ts
 │
 └── Edge Cases
-    ├── No hay ads en DB → { ads: [], message: "No ads available" }           🟡 tests/e2e.test.ts (no-match)
+    ├── No hay ads en DB → { ads: [], message: "No ads available" }           🟢 tests/integration/mcp-stdio.test.ts
     ├── Todos los campaigns pausados → resultado vacío                        🟢 tests/db/crud.test.ts
     ├── Todos los campaigns budget agotado → resultado vacío                  🟢 tests/db/crud.test.ts
     ├── max_results=1 → solo el mejor ad                                      🟢 tests/matching/ranker.test.ts
@@ -255,7 +255,7 @@ report_event
 
 ├── Atomicity (transacción SQLite)
 │   ├── insertEvent + updateAdStats + updateCampaignSpent en una transacción  🟢 tests/billing/pricing.test.ts
-│   ├── Si falla alguno → rollback completo                                   🟡 (implicit via SQLite transaction)
+│   ├── Si falla alguno → rollback completo                                   🟢 tests/billing/pricing.test.ts
 │   └── Auto-pause check dentro de la transacción                             🟢 tests/billing/pricing.test.ts
 
 ├── Output
@@ -327,12 +327,12 @@ API Keys
 Rate Limiting
 ├── Sliding window por (key_id, tool_name)                                    🟢 tests/auth/rate-limiter.test.ts
 ├── Límites
-│   ├── search_ads: 60/min                                                    🟡 (tested via configurable limits)
-│   ├── report_event: 120/min                                                 🟡 (tested via configurable limits)
-│   ├── create_campaign: 10/min                                               🟡 (tested via configurable limits)
-│   ├── create_ad: 10/min                                                     🟡 (tested via configurable limits)
-│   ├── get_campaign_analytics: 30/min                                        🟡 (tested via configurable limits)
-│   └── get_ad_guidelines: 60/min                                             🟡 (tested via configurable limits)
+│   ├── search_ads: 60/min                                                    🟢 tests/auth/rate-limiter.test.ts
+│   ├── report_event: 120/min                                                 🟢 tests/auth/rate-limiter.test.ts
+│   ├── create_campaign: 10/min                                               🟢 tests/auth/rate-limiter.test.ts
+│   ├── create_ad: 10/min                                                     🟢 tests/auth/rate-limiter.test.ts
+│   ├── get_campaign_analytics: 30/min                                        🟢 tests/auth/rate-limiter.test.ts
+│   └── get_ad_guidelines: 60/min                                             🟢 tests/auth/rate-limiter.test.ts
 ├── Excedido → RateLimitError con retryAfterMs                                🟢 tests/auth/rate-limiter.test.ts
 ├── Después del window → se resetea                                           🟢 tests/auth/rate-limiter.test.ts
 ├── Keys diferentes no interfieren                                            🟢 tests/auth/rate-limiter.test.ts
@@ -365,14 +365,14 @@ Transport: HTTP
 ├── Sessions
 │   ├── Nueva conexión → sessionId UUID                                       🟢 tests/integration/http-transport.test.ts
 │   ├── mcp-session-id header → reutiliza sesión                              🟢 tests/integration/http-transport.test.ts
-│   ├── onclose → cleanup transport + auth                                    🟡 (logic exists in server.ts; not directly tested)
-│   └── Auth se puede actualizar entre requests                               🟡 (logic exists in server.ts; not directly tested)
+│   ├── onclose → cleanup transport + auth                                    🟢 tests/integration/http-transport.test.ts
+│   └── Auth se puede actualizar entre requests                               🟡 (logic exists in server.ts; not directly tested via tool call)
 └── 404: paths desconocidos → { error: "Not found..." }                       🟢 tests/integration/http-transport.test.ts
 
 OpenClaw Skill
 ├── SKILL.md frontmatter YAML válido                                           🟢 tests/openclaw-skill.test.ts
 ├── mcp-config.example.json funcional                                          🟢 tests/openclaw-skill.test.ts
-└── README con setup guide                                                     🟡 (no separate README in openclaw-skill/)
+└── README con setup guide                                                     🟢 tests/openclaw-skill.test.ts
 ```
 
 ---

--- a/tests/auth/rate-limiter.test.ts
+++ b/tests/auth/rate-limiter.test.ts
@@ -137,6 +137,57 @@ describe('RateLimiter', () => {
     });
   });
 
+  describe('default limits per tool', () => {
+    // Verify the production DEFAULT_LIMITS are correctly configured
+    let defaultLimiter: RateLimiter;
+
+    beforeEach(() => {
+      defaultLimiter = new RateLimiter(); // Uses DEFAULT_LIMITS
+    });
+
+    it('search_ads: 60 requests/min', () => {
+      for (let i = 0; i < 60; i++) {
+        expect(defaultLimiter.check('k', 'search_ads', 0).allowed).toBe(true);
+      }
+      expect(defaultLimiter.check('k', 'search_ads', 0).allowed).toBe(false);
+    });
+
+    it('report_event: 120 requests/min', () => {
+      for (let i = 0; i < 120; i++) {
+        expect(defaultLimiter.check('k', 'report_event', 0).allowed).toBe(true);
+      }
+      expect(defaultLimiter.check('k', 'report_event', 0).allowed).toBe(false);
+    });
+
+    it('create_campaign: 10 requests/min', () => {
+      for (let i = 0; i < 10; i++) {
+        expect(defaultLimiter.check('k', 'create_campaign', 0).allowed).toBe(true);
+      }
+      expect(defaultLimiter.check('k', 'create_campaign', 0).allowed).toBe(false);
+    });
+
+    it('create_ad: 10 requests/min', () => {
+      for (let i = 0; i < 10; i++) {
+        expect(defaultLimiter.check('k', 'create_ad', 0).allowed).toBe(true);
+      }
+      expect(defaultLimiter.check('k', 'create_ad', 0).allowed).toBe(false);
+    });
+
+    it('get_campaign_analytics: 30 requests/min', () => {
+      for (let i = 0; i < 30; i++) {
+        expect(defaultLimiter.check('k', 'get_campaign_analytics', 0).allowed).toBe(true);
+      }
+      expect(defaultLimiter.check('k', 'get_campaign_analytics', 0).allowed).toBe(false);
+    });
+
+    it('get_ad_guidelines: 60 requests/min', () => {
+      for (let i = 0; i < 60; i++) {
+        expect(defaultLimiter.check('k', 'get_ad_guidelines', 0).allowed).toBe(true);
+      }
+      expect(defaultLimiter.check('k', 'get_ad_guidelines', 0).allowed).toBe(false);
+    });
+  });
+
   describe('reset', () => {
     it('clears all state', () => {
       limiter.check('key1', 'test_tool');

--- a/tests/openclaw-skill.test.ts
+++ b/tests/openclaw-skill.test.ts
@@ -9,6 +9,7 @@ import { resolve } from 'node:path';
 
 const SKILL_PATH = resolve('openclaw-skill/SKILL.md');
 const MCP_CONFIG_PATH = resolve('openclaw-skill/mcp-config.example.json');
+const README_PATH = resolve('openclaw-skill/README.md');
 
 describe('OpenClaw Skill', () => {
   describe('SKILL.md', () => {
@@ -92,6 +93,32 @@ describe('OpenClaw Skill', () => {
       expect(args).toContain('--api-key');
       const keyArg = args[args.indexOf('--api-key') + 1];
       expect(keyArg).toContain('aa_dev_');
+    });
+  });
+
+  describe('README.md', () => {
+    const content = readFileSync(README_PATH, 'utf-8');
+
+    it('exists and has setup guide', () => {
+      expect(content.length).toBeGreaterThan(100);
+      expect(content).toContain('Quick Start');
+    });
+
+    it('documents Quick Start steps', () => {
+      expect(content).toContain('API Key');
+      expect(content).toContain('Start');
+      expect(content).toContain('Configure');
+    });
+
+    it('documents available MCP tools', () => {
+      expect(content).toContain('search_ads');
+      expect(content).toContain('report_event');
+      expect(content).toContain('get_ad_guidelines');
+    });
+
+    it('mentions revenue split', () => {
+      expect(content).toContain('70%');
+      expect(content).toContain('30%');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Resolved 11 of 12 🟡 items in bulloak.md → 🟢
- Added 14 new tests across 5 files (241 → 255 total)
- 0 🔴, 1 🟡 (auth update between HTTP requests — impractical to test via raw fetch), rest 🟢

### Tests added
- **rate-limiter.test.ts**: 6 tests for DEFAULT_LIMITS per tool (search_ads: 60, report_event: 120, create_campaign: 10, create_ad: 10, get_campaign_analytics: 30, get_ad_guidelines: 60)
- **http-transport.test.ts**: Developer key session init + DELETE session cleanup
- **billing/pricing.test.ts**: Transaction rollback atomicity test
- **mcp-stdio.test.ts**: Empty DB search returns "No ads available"
- **openclaw-skill.test.ts**: README.md validation (4 tests)

## Test plan
- [x] `npx vitest run` — 255 tests passing across 13 files

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)