### PR TITLE
feat(#38, #39): update_campaign + list_campaigns — 270 tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Think "Google AdSense for AI agents." Adidas publishes a shoe ad with a $100 bud
 
 **Phase**: MVP complete — all 17 issues closed.
 
-### MCP Tools (6)
+### MCP Tools (8)
 | Tool | Auth | Description |
 |------|------|-------------|
 | `search_ads` | public | Search for relevant ads by query/keywords/category/geo |
@@ -75,6 +75,8 @@ Think "Google AdSense for AI agents." Adidas publishes a shoe ad with a $100 bud
 | `create_campaign` | advertiser | Create campaign with budget and pricing model |
 | `create_ad` | advertiser | Create ad with creative, keywords, targeting |
 | `get_campaign_analytics` | advertiser | Get campaign performance metrics |
+| `update_campaign` | advertiser | Update campaign fields, pause/resume |
+| `list_campaigns` | advertiser | List all campaigns with summary stats |
 
 ## Key Documents
 
@@ -104,4 +106,4 @@ Think "Google AdSense for AI agents." Adidas publishes a shoe ad with a $100 bud
 - All code changes require a GitHub issue first
 - Main branch is protected — PRs only
 - Before changing behavior: check bulloak.md, update it first if needed
-- After changing behavior: run `npx vitest run` (241 tests across 13 files)
+- After changing behavior: run `npx vitest run` (270 tests across 13 files)

--- a/bulloak.md
+++ b/bulloak.md
@@ -99,6 +99,39 @@ get_campaign_analytics
 └── ❌ Sin auth / developer key → error de auth                                🟢 tests/integration/mcp-stdio.test.ts
 ```
 
+```
+update_campaign
+├── ✅ Update fields parciales
+│   ├── Input: campaign_id + name, objective, total_budget, daily_budget, bid  🟢 tests/integration/mcp-stdio.test.ts
+│   ├── Output: updated campaign object con todos los campos                   🟢 tests/integration/mcp-stdio.test.ts
+│   └── DB: solo campos enviados se actualizan                                 🟢 tests/integration/mcp-stdio.test.ts
+├── ✅ Status transitions (pause / resume)
+│   ├── active → paused                                                        🟢 tests/integration/mcp-stdio.test.ts
+│   ├── paused → active                                                        🟢 tests/integration/mcp-stdio.test.ts
+│   └── completed → error "Campaign is completed and cannot be modified"       🟢 tests/integration/mcp-stdio.test.ts
+├── ❌ Reducir budget debajo de spent → error "cannot be less than spent"       🟢 tests/integration/mcp-stdio.test.ts
+├── ❌ pricing_model no se puede cambiar → error "cannot be changed"            🟡 (server rejects via Zod — no pricing_model in schema; not explicitly tested)
+├── ❌ Campaign inexistente → { error: "Campaign not found" }                   🟢 tests/integration/mcp-stdio.test.ts
+├── ❌ Campaign de otro advertiser → "does not belong to your account"          🟢 tests/integration/mcp-stdio.test.ts
+├── ❌ Sin auth → "Authentication required"                                     🟢 tests/integration/mcp-stdio.test.ts
+├── ❌ Con developer key → "requires advertiser authentication"                 🟢 tests/integration/mcp-stdio.test.ts
+└── ❌ Rate limit (>20/min) → "Rate limit exceeded"                             🟢 tests/auth/rate-limiter.test.ts
+```
+
+```
+list_campaigns
+├── ✅ Listar todos los campaigns del advertiser
+│   ├── Output: campaigns[] con id, name, status, pricing, budget summary     🟢 tests/integration/mcp-stdio.test.ts
+│   └── Ordenado por created_at DESC                                           🟢 tests/integration/mcp-stdio.test.ts
+├── ✅ Filtrar por status
+│   ├── Input: status=active → solo campaigns activos                          🟢 tests/integration/mcp-stdio.test.ts
+│   └── Input: status=paused → solo campaigns pausados                         🟢 tests/integration/mcp-stdio.test.ts
+├── ✅ Advertiser sin campaigns → { campaigns: [] }                             🟢 tests/integration/mcp-stdio.test.ts
+├── ❌ Sin auth → "Authentication required"                                     🟢 tests/integration/mcp-stdio.test.ts
+├── ❌ Con developer key → "requires advertiser authentication"                 🟢 tests/integration/mcp-stdio.test.ts
+└── ❌ Rate limit (>30/min) → "Rate limit exceeded"                             🟢 tests/auth/rate-limiter.test.ts
+```
+
 ### Budget Lifecycle
 
 ```
@@ -332,7 +365,9 @@ Rate Limiting
 │   ├── create_campaign: 10/min                                               🟢 tests/auth/rate-limiter.test.ts
 │   ├── create_ad: 10/min                                                     🟢 tests/auth/rate-limiter.test.ts
 │   ├── get_campaign_analytics: 30/min                                        🟢 tests/auth/rate-limiter.test.ts
-│   └── get_ad_guidelines: 60/min                                             🟢 tests/auth/rate-limiter.test.ts
+│   ├── get_ad_guidelines: 60/min                                             🟢 tests/auth/rate-limiter.test.ts
+│   ├── update_campaign: 20/min                                               🟢 tests/auth/rate-limiter.test.ts
+│   └── list_campaigns: 30/min                                                🟢 tests/auth/rate-limiter.test.ts
 ├── Excedido → RateLimitError con retryAfterMs                                🟢 tests/auth/rate-limiter.test.ts
 ├── Después del window → se resetea                                           🟢 tests/auth/rate-limiter.test.ts
 ├── Keys diferentes no interfieren                                            🟢 tests/auth/rate-limiter.test.ts

--- a/src/auth/rate-limiter.ts
+++ b/src/auth/rate-limiter.ts
@@ -31,6 +31,8 @@ const DEFAULT_LIMITS: Record<string, RateLimitConfig> = {
   create_ad:              { maxRequests: 10,  windowMs: 60_000 },
   get_campaign_analytics: { maxRequests: 30,  windowMs: 60_000 },
   get_ad_guidelines:      { maxRequests: 60,  windowMs: 60_000 },
+  update_campaign:        { maxRequests: 20,  windowMs: 60_000 },
+  list_campaigns:         { maxRequests: 30,  windowMs: 60_000 },
 };
 
 export class RateLimiter {

--- a/tests/auth/rate-limiter.test.ts
+++ b/tests/auth/rate-limiter.test.ts
@@ -186,6 +186,20 @@ describe('RateLimiter', () => {
       }
       expect(defaultLimiter.check('k', 'get_ad_guidelines', 0).allowed).toBe(false);
     });
+
+    it('update_campaign: 20 requests/min', () => {
+      for (let i = 0; i < 20; i++) {
+        expect(defaultLimiter.check('k', 'update_campaign', 0).allowed).toBe(true);
+      }
+      expect(defaultLimiter.check('k', 'update_campaign', 0).allowed).toBe(false);
+    });
+
+    it('list_campaigns: 30 requests/min', () => {
+      for (let i = 0; i < 30; i++) {
+        expect(defaultLimiter.check('k', 'list_campaigns', 0).allowed).toBe(true);
+      }
+      expect(defaultLimiter.check('k', 'list_campaigns', 0).allowed).toBe(false);
+    });
   });
 
   describe('reset', () => {


### PR DESCRIPTION
## Summary
- **#38 update_campaign**: Modify campaign name, objective, budget, bid, status (pause/resume). Validates ownership, budget constraints, completed campaigns.
- **#39 list_campaigns**: List all campaigns for authenticated advertiser with optional status filter and budget summary.
- Rate limits: update_campaign 20/min, list_campaigns 30/min
- 15 new tests (255 → 270 total), bulloak.md updated

## Test plan
- [x] `npx vitest run` — 270 tests passing across 13 files
- [x] Tool listing updated from 6 → 8
- [x] Auth enforcement: developer cannot call update_campaign or list_campaigns
- [x] Error paths: not found, wrong owner, completed campaign, budget below spent

Closes #38
Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)