### PR TITLE
fix(#53): use dynamic $PORT in render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -5,10 +5,8 @@ services:
     plan: free
     env: node
     buildCommand: npm install && npm run build
-    startCommand: node dist/server.js --http --port 3000
+    startCommand: node dist/server.js --http --port $PORT
     envVars:
       - key: NODE_VERSION
         value: 22.0.0
-      - key: PORT
-        value: 3000
     healthCheckPath: /health


### PR DESCRIPTION
## Summary
- Fix render.yaml to use dynamic $PORT environment variable instead of hardcoded 3000
- Remove redundant PORT env var (Render provides it automatically)
- Ensures proper deployment on Render's free tier

## Changes
- `startCommand` now uses `$PORT` variable that Render injects
- Removed explicit PORT=3000 from envVars

## Test Plan
- [ ] Deploy to Render.com
- [ ] Verify health endpoint responds at `https://<app>.onrender.com/health`
- [ ] Verify MCP endpoint works at `https://<app>.onrender.com/mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)