### PR TITLE
fix(#62): use public URL in server-card.json

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -591,12 +591,13 @@ async function startHttp() {
 
     // MCP server card for marketplace discovery (Smithery, etc.)
     if (url.pathname === '/.well-known/mcp/server-card.json') {
+      const publicBase = process.env.RENDER_EXTERNAL_URL ?? `http://localhost:${port}`;
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({
         name: 'agentic-ads',
         description: 'Ad network for AI agents — monetize MCP servers with contextual ads. 70% revenue share for developers.',
         version: '0.1.0',
-        url: `http://localhost:${port}/mcp`,
+        url: `${publicBase}/mcp`,
         transport: { type: 'streamable-http', url: '/mcp' },
         tools: [
           { name: 'search_ads', description: 'Search for relevant ads by query, keywords, category, or geo' },


### PR DESCRIPTION
## Summary
- Server-card.json was returning `http://localhost:10000/mcp` (Render's internal port)
- Smithery's scan read this, tried to connect to localhost, got 404
- Now uses `RENDER_EXTERNAL_URL` env var (auto-set by Render) for production
- Falls back to `http://localhost:{port}` for local development

## Test plan
- [x] 270/270 tests pass
- [x] Build succeeds
- [ ] After deploy, verify `curl https://agentic-ads.onrender.com/.well-known/mcp/server-card.json` returns public URL
- [ ] Retry `smithery mcp publish`

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)