### PR TITLE
fix(#62): derive server-card URL from Host header

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -591,7 +591,9 @@ async function startHttp() {
 
     // MCP server card for marketplace discovery (Smithery, etc.)
     if (url.pathname === '/.well-known/mcp/server-card.json') {
-      const publicBase = process.env.RENDER_EXTERNAL_URL ?? `http://localhost:${port}`;
+      const host = req.headers.host;
+      const proto = req.headers['x-forwarded-proto'] === 'https' ? 'https' : (host?.includes('localhost') ? 'http' : 'https');
+      const publicBase = host ? `${proto}://${host}` : `http://localhost:${port}`;
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({
         name: 'agentic-ads',


### PR DESCRIPTION
## Summary
- Replaces `RENDER_EXTERNAL_URL` env var approach with dynamic `Host` header detection
- Uses `X-Forwarded-Proto` to determine HTTPS vs HTTP (behind reverse proxies)
- Works on any hosting platform without platform-specific configuration
- Fixes Smithery 404 scan failure caused by server-card returning `localhost:10000`

## Test plan
- [x] 270/270 tests pass
- [x] Build succeeds
- [ ] After deploy: `curl https://agentic-ads.onrender.com/.well-known/mcp/server-card.json` should return `https://agentic-ads.onrender.com/mcp`
- [ ] Retry Smithery publish

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)