### PR TITLE
fix: correct server.json schema for MCP Registry

### DIFF
--- a/server.json
+++ b/server.json
@@ -21,7 +21,7 @@
   ],
   "remotes": [
     {
-      "transportType": "streamable-http",
+      "type": "streamable-http",
       "url": "https://agentic-ads.onrender.com/mcp"
     }
   ]


### PR DESCRIPTION
## Summary
- Fixed `transportType` → `type` in remotes array to match registry schema
- Successfully published `io.github.nicofains1/agentic-ads` v0.1.1 to the Official MCP Registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)