### PR TITLE
feat(#62): fix DB persistence — DATABASE_PATH env var + Fly.io deployment config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,14 @@ RUN npm ci --only=production
 # Copy built files
 COPY dist ./dist
 
-# SQLite database will be stored in /data
+# Copy startup script
+COPY scripts/start.sh ./scripts/start.sh
+RUN chmod +x scripts/start.sh
+
+# SQLite database will be stored in /data (persistent volume mount point)
 RUN mkdir -p /data
 ENV DATABASE_PATH=/data/agentic-ads.db
 
 EXPOSE 3000
 
-CMD ["node", "dist/server.js", "--http", "--port", "3000"]
+CMD ["sh", "scripts/start.sh"]

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Response:
 
 Use the `api_key` in the `Authorization` header: `Authorization: Bearer aa_dev_...`
 
-> **Note on Render free tier:** The live server at `agentic-ads.onrender.com` runs on Render's free tier, which spins down after 15 minutes of inactivity. Cold starts may take 15-30 seconds. The SQLite database is ephemeral — data resets on each deploy. For persistent data, self-host the server (Option 3 below) or use a paid Render plan.
+> **Note on Render free tier:** The live server at `agentic-ads.onrender.com` runs on Render's free tier, which spins down after 15 minutes of inactivity. Cold starts may take 15-30 seconds. The SQLite database is ephemeral on the free tier — data resets on each deploy. **For persistent data**, deploy to [Fly.io](DEPLOY.md) (free, persistent volume) or self-host with `DATABASE_PATH=/data/ads.db` pointing to a mounted volume.
 
 ---
 
@@ -308,8 +308,11 @@ node dist/server.js --http --port 19877 --db ./ads.db
 
 ```bash
 PORT=19877                     # HTTP server port (alternative to --port)
+DATABASE_PATH=/data/ads.db     # SQLite database path (default: agentic-ads.db)
 AGENTIC_ADS_API_KEY=aa_dev_... # Developer API key for stdio mode
 ```
+
+**DB Persistence:** Set `DATABASE_PATH` to a path on a persistent volume. On first run with an empty DB, demo campaigns are auto-seeded. See [DEPLOY.md](DEPLOY.md) for full deployment guide (Fly.io recommended for free persistent storage).
 
 ---
 

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,36 @@
+# Fly.io deployment config for agentic-ads
+# Free tier: 3 shared-cpu VMs, 256MB RAM, 3GB persistent volume
+# Docs: https://fly.io/docs/reference/configuration/
+
+app = "agentic-ads"
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PORT = "3000"
+  DATABASE_PATH = "/data/agentic-ads.db"
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [[http_service.checks]]
+    grace_period = "10s"
+    interval = "30s"
+    method = "GET"
+    timeout = "5s"
+    path = "/health"
+
+[[mounts]]
+  source = "agentic_ads_data"
+  destination = "/data"
+  initial_size = "1gb"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "256mb"

--- a/railway.toml
+++ b/railway.toml
@@ -1,9 +1,13 @@
 [build]
 builder = "NIXPACKS"
+buildCommand = "npm install && npm run build"
 
 [deploy]
-startCommand = "node dist/server.js --http --port 3000"
+startCommand = "node dist/server.js --http --port $PORT"
 healthcheckPath = "/health"
 healthcheckTimeout = 300
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 10
+
+# DATABASE_PATH is set via Railway volume mount at /data
+# Set this env var in Railway dashboard or via: railway variables set DATABASE_PATH=/data/agentic-ads.db

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Startup script — ensures DB directory exists before starting server
+# Used by Docker container to handle persistent volume mounts
+
+set -e
+
+# Ensure DB directory exists (for mounted volumes)
+DB_PATH="${DATABASE_PATH:-/data/agentic-ads.db}"
+DB_DIR="$(dirname "$DB_PATH")"
+
+if [ "$DB_DIR" != "." ] && [ "$DB_DIR" != "" ]; then
+  mkdir -p "$DB_DIR"
+  echo "[startup] DB directory ensured: $DB_DIR"
+fi
+
+echo "[startup] Starting agentic-ads with DATABASE_PATH=$DB_PATH"
+
+# Use PORT from env (Railway/Fly.io set this) or default to 3000
+exec node dist/server.js --http --port "${PORT:-3000}"

--- a/src/server.ts
+++ b/src/server.ts
@@ -26,7 +26,8 @@ const portFlag = args.indexOf('--port');
 const port = portFlag !== -1 ? parseInt(args[portFlag + 1], 10) : 3000;
 
 const dbPathFlag = args.indexOf('--db');
-const dbPath = dbPathFlag !== -1 ? args[dbPathFlag + 1] : 'agentic-ads.db';
+// Priority: --db CLI flag > DATABASE_PATH env var > default file
+const dbPath = dbPathFlag !== -1 ? args[dbPathFlag + 1] : (process.env.DATABASE_PATH ?? 'agentic-ads.db');
 
 const apiKeyFlag = args.indexOf('--api-key');
 const cliApiKey = apiKeyFlag !== -1 ? args[apiKeyFlag + 1] : process.env.AGENTIC_ADS_API_KEY;


### PR DESCRIPTION
## Summary

- Fixes the Render free tier DB loss issue by making `DATABASE_PATH` env var the primary path config
- Adds `fly.toml` for Fly.io deployment with 1GB persistent volume at `/data`
- Adds `scripts/start.sh` startup script that ensures the volume mount directory exists
- Updates `railway.toml` to use `$PORT` and explicit build command
- Fully rewrites `DEPLOY.md` with Fly.io as primary option (free + persistent)

## Root Cause

The server defaulted to `agentic-ads.db` in the working directory. There was no way to tell it to use a different path without the `--db` CLI flag. Render (and Railway via Nixpacks) don't persist working directory files across deploys.

## Fix

Priority chain for DB path: `--db` CLI flag > `DATABASE_PATH` env var > `agentic-ads.db` default.

Any platform can now set `DATABASE_PATH=/data/agentic-ads.db` with a persistent volume at `/data`.

## Deployment Decision

- **Railway**: blocked — free plan resource limit exceeded (can't create new services)
- **Fly.io**: selected — `flyctl` already installed, free tier has persistent volumes, needs `flyctl auth login` to deploy (browser auth required — human blocker for actual deploy)

## Test Plan

- [x] `pnpm build` — no TypeScript errors
- [x] `pnpm test` — all 270 tests pass
- [x] Auto-seed still works (server checks for empty DB on startup)
- [x] `DATABASE_PATH` env var is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)