### PR TITLE
feat(#72): star-worthy repo — LICENSE, hero README, badges, Quick Start

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 agentic-ads contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,59 @@
 # Agentic Ads
 
-**Turn your MCP server into a revenue stream in 5 minutes.**
+> **Google AdSense for AI agents.** Add 3 lines of code to your MCP server. Earn 70% of every ad click.
 
+[![npm version](https://img.shields.io/npm/v/agentic-ads?color=blue&label=npm)](https://www.npmjs.com/package/agentic-ads)
 [![Tests](https://img.shields.io/badge/tests-270%20passing-brightgreen)](https://github.com/nicofains1/agentic-ads)
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![MCP](https://img.shields.io/badge/MCP-v1.12.0-orange)](https://modelcontextprotocol.io)
 [![Node](https://img.shields.io/badge/node-%3E%3D22.0.0-brightgreen)](https://nodejs.org)
+
+**[Live Demo](https://agentic-ads.onrender.com/health)** · **[Quick Start](#quick-start)** · **[MCP Tools](#mcp-tools-8-total)** · **[Self-Host](#option-3-self-host-production)**
+
+---
+
+## Quick Start
+
+**Step 1 — Register and get your API key (30 seconds):**
+
+```bash
+curl -X POST https://agentic-ads.onrender.com/api/register \
+  -H "Content-Type: application/json" \
+  -d '{"name": "My MCP Bot", "email": "me@example.com"}'
+# Returns: { "api_key": "aa_dev_...", "mcp_url": "https://agentic-ads.onrender.com/mcp" }
+```
+
+**Step 2 — Add to your MCP client config:**
+
+```json
+{
+  "mcpServers": {
+    "agentic-ads": {
+      "url": "https://agentic-ads.onrender.com/mcp",
+      "transport": "http"
+    }
+  }
+}
+```
+
+**Step 3 — Call `search_ads` in your agent and earn on every click:**
+
+```typescript
+// In your agent logic — when context is relevant
+const ads = await mcp.callTool({
+  name: 'search_ads',
+  arguments: { query: 'best running shoes for marathon', max_results: 1 }
+});
+
+// Report events to get paid
+await mcp.callTool({
+  name: 'report_event',
+  arguments: { ad_id: ads[0].ad_id, event_type: 'impression' }
+});
+// User clicks → report 'click' → you earn $0.35 on a $0.50 CPC ad
+```
+
+That's it. You're monetizing.
 
 ---
 
@@ -43,23 +91,11 @@ That's **$21,000/year** for adding 3 lines of code to your MCP server.
 
 ---
 
-## 30-Second Quickstart
+## Detailed Integration Guide
 
 ### For MCP Developers (Earn Money)
 
-```bash
-# Add to your MCP client config
-{
-  "mcpServers": {
-    "agentic-ads": {
-      "url": "https://agentic-ads.onrender.com/mcp",
-      "transport": "http"
-    }
-  }
-}
-```
-
-Then in your agent logic:
+Connect the live server and start calling tools — no approval process, no minimums.
 
 ```typescript
 // 1. When user asks about products/services
@@ -81,8 +117,6 @@ await mcp.callTool({
 // 4. If user clicks → report 'click' event
 // You earn $0.35 on a $0.50 CPC click (70% revenue share)
 ```
-
-**That's it.** You're monetizing.
 
 ### For Advertisers (Reach AI Users)
 


### PR DESCRIPTION
## Summary

- Add MIT LICENSE file (was missing — README referenced it but file didn't exist)
- Improve README first impression: hero tagline, npm badge, navigation links
- Add 3-step Quick Start section at the very top of README
- Rename duplicate quickstart section to "Detailed Integration Guide"

## Changes

- `LICENSE` — new MIT license file
- `README.md` — hero tagline, npm badge, navigation links, Quick Start section

Closes #72