### PR TITLE
docs(#69): add How Developers Get Paid section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,12 @@ tsx scripts/smoke-test.ts --db test.db --dev-key aa_dev_... --adv-key aa_adv_...
 
 ---
 
+## How Developers Get Paid
+
+When your MCP server reports a click event on a CPC ad, 70% of the bid goes to you — tracked atomically in our database. Once your balance reaches **$10**, email `payouts@agentic-ads.com` with your developer_id and your preferred payment method (PayPal or USDC on Polygon). We verify your balance and send payment within 5 business days. Automated Stripe payouts are on the roadmap for when the network scales.
+
+---
+
 ## FAQ
 
 ### For Developers


### PR DESCRIPTION
## Summary

- Adds a "How Developers Get Paid" section to the README explaining the payout process
- $10 minimum threshold, email payouts@ with developer_id, PayPal or USDC on Polygon, 5 business day turnaround
- Closes the biggest trust gap in the developer onboarding journey (identified in CPO audit issue #69)

## Test plan

- [ ] Verify section renders correctly in GitHub README preview
- [ ] Confirm payout email address is set up or forwarded before this goes live

🤖 Generated with [Claude Code](https://claude.com/claude-code)