### PR TITLE
fix: repair examples/ broken deps and SSE parsing

### DIFF
--- a/examples/demo-mcp-server/package-lock.json
+++ b/examples/demo-mcp-server/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.12.0"
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "zod": "^3.24.0"
       },
       "bin": {
         "demo-mcp-server": "build/index.js"
@@ -1159,9 +1160,9 @@
       "license": "ISC"
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/examples/demo-mcp-server/package.json
+++ b/examples/demo-mcp-server/package.json
@@ -23,7 +23,8 @@
   "author": "Agentic Ads",
   "license": "MIT",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.12.0"
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.5",

--- a/examples/simple-mcp-with-ads/package.json
+++ b/examples/simple-mcp-with-ads/package.json
@@ -19,8 +19,7 @@
   "author": "Agentic Ads",
   "license": "MIT",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.4",
-    "agentic-ads": "^0.1.1"
+    "@modelcontextprotocol/sdk": "^1.12.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.5",


### PR DESCRIPTION
## Summary

- **demo-mcp-server**: Added `zod` as explicit dependency (was relying on transitive dep from `@modelcontextprotocol/sdk` — fragile, breaks if SDK changes its deps)
- **simple-mcp-with-ads**: Removed unused `agentic-ads` dependency that pulled in `better-sqlite3` native compilation, causing `npm install` failures on machines without C++ build tools
- **simple-mcp-with-ads**: Updated `@modelcontextprotocol/sdk` from `^1.0.4` to `^1.12.0`
- **simple-mcp-with-ads**: Fixed SSE response parsing (was using `.json()` which fails on `text/event-stream` format from agentic-ads server)
- **simple-mcp-with-ads**: Removed dead `reportEvent` function (never called)

## Test plan

- [x] `npm install && npm run build` succeeds for both examples (clean, no node_modules)
- [x] Both examples start and run on stdio without errors
- [x] simple-mcp-with-ads installs 94 packages instead of 131 (no native compilation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)