### PR TITLE
Schema migration: wallet, verification, chain config

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -16,6 +16,8 @@ export interface Developer {
   id: string;
   name: string;
   email: string | null;
+  wallet_address: string | null;
+  referral_code: string | null;
   reputation_score: number;
   created_at: string;
 }
@@ -33,6 +35,9 @@ export interface Campaign {
   bid_amount: number;
   start_date: string | null;
   end_date: string | null;
+  verification_type: 'trust' | 'on_chain';
+  contract_address: string | null;
+  chain_ids: number[];
   created_at: string;
 }
 
@@ -54,6 +59,8 @@ export interface Ad {
   created_at: string;
 }
 
+export type VerificationStatus = 'none' | 'pending' | 'verified' | 'rejected';
+
 export interface Event {
   id: string;
   ad_id: string;
@@ -64,6 +71,19 @@ export interface Event {
   platform_revenue: number;
   context_hash: string | null;
   metadata: Record<string, unknown>;
+  tx_hash: string | null;
+  chain_id: number | null;
+  verification_status: VerificationStatus;
+  verified_at: string | null;
+  verification_details: Record<string, unknown>;
+  created_at: string;
+}
+
+export interface ChainConfig {
+  chain_id: number;
+  name: string;
+  rpc_url: string;
+  explorer_url: string | null;
   created_at: string;
 }
 
@@ -95,6 +115,25 @@ export interface AdRow {
   created_at: string;
 }
 
+export interface CampaignRow {
+  id: string;
+  advertiser_id: string;
+  name: string;
+  objective: 'awareness' | 'traffic' | 'conversions';
+  status: 'draft' | 'active' | 'paused' | 'completed';
+  total_budget: number;
+  daily_budget: number | null;
+  spent: number;
+  pricing_model: 'cpm' | 'cpc' | 'cpa' | 'hybrid';
+  bid_amount: number;
+  start_date: string | null;
+  end_date: string | null;
+  verification_type: 'trust' | 'on_chain';
+  contract_address: string | null;
+  chain_ids: string;     // JSON TEXT
+  created_at: string;
+}
+
 export interface EventRow {
   id: string;
   ad_id: string;
@@ -105,6 +144,11 @@ export interface EventRow {
   platform_revenue: number;
   context_hash: string | null;
   metadata: string;      // JSON TEXT
+  tx_hash: string | null;
+  chain_id: number | null;
+  verification_status: VerificationStatus;
+  verified_at: string | null;
+  verification_details: string; // JSON TEXT
   created_at: string;
 }
 
@@ -123,6 +167,8 @@ CREATE TABLE IF NOT EXISTS developers (
   id                TEXT PRIMARY KEY,
   name              TEXT NOT NULL,
   email             TEXT,
+  wallet_address    TEXT,
+  referral_code     TEXT,
   reputation_score  REAL DEFAULT 1.0,
   created_at        TEXT DEFAULT CURRENT_TIMESTAMP
 );
@@ -138,9 +184,12 @@ CREATE TABLE IF NOT EXISTS campaigns (
   spent           REAL DEFAULT 0,
   pricing_model   TEXT NOT NULL CHECK(pricing_model IN ('cpm','cpc','cpa','hybrid')),
   bid_amount      REAL NOT NULL,
-  start_date      TEXT,
-  end_date        TEXT,
-  created_at      TEXT DEFAULT CURRENT_TIMESTAMP
+  start_date          TEXT,
+  end_date            TEXT,
+  verification_type   TEXT DEFAULT 'trust' CHECK(verification_type IN ('trust','on_chain')),
+  contract_address    TEXT,
+  chain_ids           TEXT DEFAULT '[]',
+  created_at          TEXT DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS ads (
@@ -169,9 +218,22 @@ CREATE TABLE IF NOT EXISTS events (
   amount_charged    REAL NOT NULL DEFAULT 0,
   developer_revenue REAL NOT NULL DEFAULT 0,
   platform_revenue  REAL NOT NULL DEFAULT 0,
-  context_hash      TEXT,
-  metadata          TEXT DEFAULT '{}',
-  created_at        TEXT DEFAULT CURRENT_TIMESTAMP
+  context_hash          TEXT,
+  metadata              TEXT DEFAULT '{}',
+  tx_hash               TEXT,
+  chain_id              INTEGER,
+  verification_status   TEXT DEFAULT 'none' CHECK(verification_status IN ('none','pending','verified','rejected')),
+  verified_at           TEXT,
+  verification_details  TEXT DEFAULT '{}',
+  created_at            TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS chain_configs (
+  chain_id      INTEGER PRIMARY KEY,
+  name          TEXT NOT NULL,
+  rpc_url       TEXT NOT NULL,
+  explorer_url  TEXT,
+  created_at    TEXT DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS api_keys (
@@ -192,4 +254,54 @@ CREATE INDEX IF NOT EXISTS idx_events_developer_id   ON events(developer_id);
 CREATE INDEX IF NOT EXISTS idx_events_created_at     ON events(created_at);
 CREATE INDEX IF NOT EXISTS idx_api_keys_key_hash     ON api_keys(key_hash);
 CREATE INDEX IF NOT EXISTS idx_events_dedup          ON events(developer_id, ad_id, event_type, created_at);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_developers_wallet   ON developers(wallet_address) WHERE wallet_address IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_developers_referral ON developers(referral_code) WHERE referral_code IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_events_tx_hash      ON events(tx_hash) WHERE tx_hash IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_events_verification        ON events(verification_status) WHERE verification_status = 'pending';
 `;
+
+// ─── Migration SQL (for existing databases) ────────────────────────────────
+
+export const MIGRATION_V2_SQL = `
+-- developers: add wallet fields
+ALTER TABLE developers ADD COLUMN wallet_address TEXT;
+ALTER TABLE developers ADD COLUMN referral_code TEXT;
+
+-- campaigns: add verification fields
+ALTER TABLE campaigns ADD COLUMN verification_type TEXT DEFAULT 'trust' CHECK(verification_type IN ('trust','on_chain'));
+ALTER TABLE campaigns ADD COLUMN contract_address TEXT;
+ALTER TABLE campaigns ADD COLUMN chain_ids TEXT DEFAULT '[]';
+
+-- events: add blockchain verification fields
+ALTER TABLE events ADD COLUMN tx_hash TEXT;
+ALTER TABLE events ADD COLUMN chain_id INTEGER;
+ALTER TABLE events ADD COLUMN verification_status TEXT DEFAULT 'none' CHECK(verification_status IN ('none','pending','verified','rejected'));
+ALTER TABLE events ADD COLUMN verified_at TEXT;
+ALTER TABLE events ADD COLUMN verification_details TEXT DEFAULT '{}';
+
+-- chain_configs table
+CREATE TABLE IF NOT EXISTS chain_configs (
+  chain_id      INTEGER PRIMARY KEY,
+  name          TEXT NOT NULL,
+  rpc_url       TEXT NOT NULL,
+  explorer_url  TEXT,
+  created_at    TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+-- new indexes
+CREATE UNIQUE INDEX IF NOT EXISTS idx_developers_wallet   ON developers(wallet_address) WHERE wallet_address IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_developers_referral ON developers(referral_code) WHERE referral_code IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_events_tx_hash      ON events(tx_hash) WHERE tx_hash IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_events_verification        ON events(verification_status) WHERE verification_status = 'pending';
+`;
+
+// ─── Chain config seed data ─────────────────────────────────────────────────
+
+export const CHAIN_CONFIGS_SEED = [
+  { chain_id: 1, name: 'Ethereum', rpc_url: 'https://eth.drpc.org', explorer_url: 'https://etherscan.io' },
+  { chain_id: 10, name: 'Optimism', rpc_url: 'https://mainnet.optimism.io', explorer_url: 'https://optimistic.etherscan.io' },
+  { chain_id: 137, name: 'Polygon', rpc_url: 'https://polygon-bor-rpc.publicnode.com', explorer_url: 'https://polygonscan.com' },
+  { chain_id: 8453, name: 'Base', rpc_url: 'https://mainnet.base.org', explorer_url: 'https://basescan.org' },
+  { chain_id: 42161, name: 'Arbitrum', rpc_url: 'https://arb1.arbitrum.io/rpc', explorer_url: 'https://arbiscan.io' },
+  { chain_id: 43114, name: 'Avalanche', rpc_url: 'https://api.avax.network/ext/bc/C/rpc', explorer_url: 'https://snowtrace.io' },
+];


### PR DESCRIPTION
## Summary
- Adds wallet_address + referral_code to developers table
- Adds verification_type (trust/on_chain), contract_address, chain_ids to campaigns
- Adds tx_hash, chain_id, verification_status, verified_at, verification_details to events
- New chain_configs table with 6 pre-seeded public RPCs
- Idempotent migration for existing databases (ALTER TABLE with existence check)
- 12 new CRUD functions for wallet management, chain configs, and verification

Closes #81

## Test plan
- [x] 274 existing tests pass (no regressions)
- [x] Build passes
- [ ] Verify migration works on M1 with existing DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)