### PR TITLE
fix(#100): re-add fly.toml with min_machines_running=1

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,35 @@
+# fly.toml — Fly.io deployment config for agentic-ads
+# Required by `flyctl deploy` and the GitHub Actions CD pipeline.
+
+app = 'agentic-ads'
+primary_region = 'iad'
+
+[build]
+  dockerfile = 'Dockerfile'
+
+[env]
+  DATABASE_PATH = '/data/agentic-ads.db'
+  PORT = '3000'
+
+[[mounts]]
+  source = 'agentic_ads_data'
+  destination = '/data'
+  initial_size = '1gb'
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [[http_service.checks]]
+    interval = '30s'
+    timeout = '5s'
+    grace_period = '10s'
+    method = 'GET'
+    path = '/health'
+
+[[vm]]
+  size = 'shared-cpu-1x'
+  memory = '256mb'


### PR DESCRIPTION
## Summary
- Re-adds `fly.toml` with `min_machines_running = 1` (was `0`)
- Prevents the 502 outage where the Fly.io machine fully stops and `auto_start` fails silently
- `fly.toml` was removed in PR #96 to stop Railway deploy spam, but it's required for `flyctl deploy`. Railway config is already gone.

## After merging
Owner needs to:
1. Install flyctl: `brew install flyctl`
2. Auth: `flyctl auth login`
3. Deploy: `cd agentic-ads && flyctl deploy`

## Future: CD pipeline
A `deploy.yml` GitHub Action is ready but couldn't be pushed (token lacks `workflow` scope). Owner should:
1. Add `FLY_API_TOKEN` as a GitHub secret
2. Add `.github/workflows/deploy.yml` (saved locally at `/Users/nfainstein/Software-Development/agentic-ads/.github/workflows/deploy.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)