### PR TITLE
feat(#110): migrate payments from Polygon to Base

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -334,7 +334,7 @@ server.tool(
     context_hash: z.string().optional().describe('Hash of the message containing the ad (for verification)'),
     metadata: z.record(z.unknown()).optional().describe('Additional event metadata'),
     tx_hash: z.string().optional().describe('Transaction hash for on-chain verified conversions'),
-    chain_id: z.number().optional().describe('Chain ID for on-chain verified conversions (e.g. 137 for Polygon)'),
+    chain_id: z.number().optional().describe('Chain ID for on-chain verified conversions (e.g. 8453 for Base)'),
   },
   async (params, extra) => {
     logToolCall('report_event', extra.sessionId);
@@ -1097,7 +1097,7 @@ server.tool(
             wallet_address: completed.wallet_address,
             tx_hash: completed.tx_hash,
             status: 'completed',
-            explorer_url: `https://polygonscan.com/tx/${completed.tx_hash}`,
+            explorer_url: `https://basescan.org/tx/${completed.tx_hash}`,
             remaining_balance: Math.round((available - amount) * 100) / 100,
           }),
         }],

--- a/tests/integration/mcp-stdio.test.ts
+++ b/tests/integration/mcp-stdio.test.ts
@@ -89,6 +89,7 @@ describe('MCP Integration: stdio transport', () => {
           'list_campaigns',
           'register_wallet',
           'report_event',
+          'request_withdrawal',
           'search_ads',
           'update_campaign',
         ]);


### PR DESCRIPTION
## Summary
- Migrate USDC payments from Polygon (USDC.e bridged) to Base (native USDC)
- 3 constants changed in withdraw.ts (chain, USDC address, RPC)
- Explorer URL updated to basescan.org

## Changes
- `src/payments/withdraw.ts`: polygon -> base, USDC.e -> native USDC, new RPC
- `src/server.ts`: explorer polygonscan -> basescan, description update
- `tests/integration/mcp-stdio.test.ts`: add request_withdrawal to tool list

## Test plan
- [x] pnpm build passes
- [x] 361/361 tests passing
- [ ] Deploy to Railway
- [ ] Update BASE_RPC_URL env var
- [ ] E2E withdrawal test on Base

Generated with [Claude Code](https://claude.com/claude-code)