### PR TITLE
fix(#122,#124): autoSeed guard + partial-match false positive + DigitalOcean referral link

### DIFF
--- a/src/matching/keyword-matcher.ts
+++ b/src/matching/keyword-matcher.ts
@@ -89,7 +89,10 @@ export function matchAds(query: SearchQuery, ads: AdCandidate[]): MatchResult[] 
           if (!exact_keyword_matches.includes(ak)) {
             exact_keyword_matches.push(ak);
           }
-        } else if (ak.includes(qk) || qk.includes(ak)) {
+        } else if (qk.length >= 4 && (ak.includes(qk) || qk.includes(ak))) {
+          // Require query keyword >= 4 chars for partial matching to prevent
+          // short generic terms (e.g. "ads", "dev") from false-positive matching
+          // long ad keywords (e.g. "adsense for ai"). Fixes #124.
           if (!partial_keyword_matches.includes(ak)) {
             partial_keyword_matches.push(ak);
           }

--- a/src/server.ts
+++ b/src/server.ts
@@ -50,11 +50,11 @@ console.error(`[agentic-ads] Database initialized at: ${dbPath}`);
 // ─── Auto-Seed Production DB ─────────────────────────────────────────────────
 
 function autoSeed() {
-  const advCount = (db.prepare('SELECT COUNT(*) as c FROM advertisers').get() as { c: number }).c;
-  const devCount = (db.prepare('SELECT COUNT(*) as c FROM developers').get() as { c: number }).c;
-  if (advCount > 0 || devCount > 0) return; // Already seeded or pre-populated
+  // Check by signature advertiser name to avoid skipping when DB has unrelated/test data (#122)
+  const alreadySeeded = (db.prepare("SELECT COUNT(*) as c FROM advertisers WHERE name = 'OnlySwaps'").get() as { c: number }).c;
+  if (alreadySeeded > 0) return; // Production campaigns already present
 
-  console.error('[agentic-ads] Empty database detected — auto-seeding production campaigns...');
+  console.error('[agentic-ads] Production campaigns not found — auto-seeding...');
 
   // OnlySwaps — Web3 token swapper
   const onlyswaps = createAdvertiser(db, {
@@ -217,7 +217,7 @@ function autoSeed() {
   createAd(db, {
     campaign_id: doCampaign.id,
     creative_text: 'Deploy apps, databases, and Kubernetes on DigitalOcean. Developer-friendly cloud starting at $4/month. $200 free credit for new users.',
-    link_url: 'https://www.digitalocean.com',
+    link_url: 'https://m.do.co/c/af5c18972daf',
     keywords: ['vps', 'cloud hosting', 'digitalocean', 'droplet', 'kubernetes', 'managed postgres', 'cloud server'],
     categories: ['hosting', 'cloud', 'infrastructure'],
     geo: 'ALL',
@@ -226,7 +226,7 @@ function autoSeed() {
   createAd(db, {
     campaign_id: doCampaign.id,
     creative_text: 'DigitalOcean App Platform: deploy from GitHub, auto-scales, managed SSL. Skip the AWS complexity. Simple pricing, great documentation.',
-    link_url: 'https://www.digitalocean.com/products/app-platform',
+    link_url: 'https://m.do.co/c/af5c18972daf',
     keywords: ['app platform', 'heroku alternative', 'github deploy', 'managed hosting', 'paas'],
     categories: ['hosting', 'deployment', 'paas'],
     geo: 'ALL',


### PR DESCRIPTION
## Summary

- **#122 — autoSeed skips non-empty DB**: Changed guard from `advCount > 0 || devCount > 0` (total row count) to a named lookup for `OnlySwaps`. Previously, any pre-existing test data (Adidas/Spotify from `scripts/seed.ts`) would cause all affiliate campaigns to be skipped on startup. Now production campaigns always get seeded when the signature advertiser is missing.

- **#124 — keyword "ads" false positive**: Added `qk.length >= 4` guard to partial/substring matching in `keyword-matcher.ts`. Short query terms like "ads" were matching ad keywords like "adsense for ai" via substring check, producing a spurious score of 0.30. Fix requires query keywords to be at least 4 chars before partial matching is attempted — exact matches still work for all lengths.

- **DigitalOcean referral link**: Updated both DigitalOcean ad `link_url`s from generic `https://www.digitalocean.com` to the real referral link `https://m.do.co/c/af5c18972daf` (10% recurring commission for 12 months). This means every DigitalOcean click from an AI agent now generates affiliate revenue.

## Test plan

- [x] 385/385 tests passing (`pnpm test` on Node 22)
- [x] Keyword matcher tests: `tests/matching/keyword-matcher.test.ts` (28 tests)
- [x] Min-relevance filter tests: `tests/tools/search-ads-min-relevance.test.ts` (8 tests)
- [x] Full MCP E2E: `tests/integration/mcp-stdio.test.ts` (46 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)