### PR TITLE
fix(#128): update server.json remote URL to Railway

### DIFF
--- a/server.json
+++ b/server.json
@@ -22,7 +22,7 @@
   "remotes": [
     {
       "type": "streamable-http",
-      "url": "https://agentic-ads.fly.dev/mcp"
+      "url": "https://agentic-ads-production.up.railway.app/mcp"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Updates `server.json` remote URL from dead Fly.io (`https://agentic-ads.fly.dev/mcp`) to live Railway (`https://agentic-ads-production.up.railway.app/mcp`)

## Test plan
- [x] Verified URL matches live deployment in CLAUDE.md and README

🤖 Generated with [Claude Code](https://claude.com/claude-code)