### PR TITLE
fix: skip auto-seed in empty-DB test

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -533,7 +533,7 @@ function autoSeed() {
   }
 }
 
-autoSeed();
+if (!process.env.NO_AUTO_SEED) autoSeed();
 
 // ─── Auth Context ─────────────────────────────────────────────────────────────
 

--- a/tests/integration/mcp-stdio.test.ts
+++ b/tests/integration/mcp-stdio.test.ts
@@ -1160,7 +1160,13 @@ describe('MCP Integration: stdio transport', () => {
       const emptyDevKey = (await import('../../src/auth/middleware.js')).generateApiKey(emptyDb, 'developer', emptyDev.id);
       emptyDb.close();
 
-      const client = await createMcpClient(emptyDbPath, emptyDevKey);
+      const transport = new StdioClientTransport({
+        command: 'node',
+        args: [SERVER_PATH, '--stdio', '--db', emptyDbPath, '--api-key', emptyDevKey],
+        env: { ...process.env, NO_AUTO_SEED: '1' },
+      });
+      const client = new Client({ name: 'integration-test', version: '1.0.0' });
+      await client.connect(transport);
       try {
         const result = await client.callTool({
           name: 'search_ads',


### PR DESCRIPTION
## Summary
- Auto-seed was populating fresh test databases with default campaigns, causing the "search_ads with no ads in DB" test to fail (expected empty results, got OnlySwaps/Binance ads)
- Added `NO_AUTO_SEED` env var check to `server.ts` — when set, skips auto-seed on startup
- Updated the empty-DB test to pass `NO_AUTO_SEED=1` when spawning the MCP server process

## Test plan
- [x] `npm run build` — clean compile
- [x] `npm test` — 385/385 passing (was 384/385 before fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)