### PR TITLE
fix(#141): add build tools to Dockerfile builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:22-alpine AS builder
 WORKDIR /app
+RUN apk add --no-cache python3 make g++
 COPY package*.json tsconfig.json ./
 COPY src ./src
 RUN npm ci && npm run build

--- a/src/server.ts
+++ b/src/server.ts
@@ -533,7 +533,7 @@ function autoSeed() {
   }
 }
 
-autoSeed();
+if (!process.env.NO_AUTO_SEED) autoSeed();
 
 // ─── Auth Context ─────────────────────────────────────────────────────────────
 

--- a/tests/integration/mcp-stdio.test.ts
+++ b/tests/integration/mcp-stdio.test.ts
@@ -19,10 +19,11 @@ const SERVER_PATH = resolve('dist/server.js');
 
 // ─── Helper: create MCP client connected to server via stdio ──────────────────
 
-async function createMcpClient(dbPath: string, apiKey: string): Promise<Client> {
+async function createMcpClient(dbPath: string, apiKey: string, env?: Record<string, string>): Promise<Client> {
   const transport = new StdioClientTransport({
     command: 'node',
     args: [SERVER_PATH, '--stdio', '--db', dbPath, '--api-key', apiKey],
+    env: { ...process.env, ...env },
   });
   const client = new Client({ name: 'integration-test', version: '1.0.0' });
   await client.connect(transport);
@@ -1160,7 +1161,7 @@ describe('MCP Integration: stdio transport', () => {
       const emptyDevKey = (await import('../../src/auth/middleware.js')).generateApiKey(emptyDb, 'developer', emptyDev.id);
       emptyDb.close();
 
-      const client = await createMcpClient(emptyDbPath, emptyDevKey);
+      const client = await createMcpClient(emptyDbPath, emptyDevKey, { NO_AUTO_SEED: '1' });
       try {
         const result = await client.callTool({
           name: 'search_ads',


### PR DESCRIPTION
## Summary
- Add `python3`, `make`, and `g++` to the Dockerfile **builder stage** so `better-sqlite3` native addons compile successfully during `npm ci`
- Add `NO_AUTO_SEED` env var guard to skip auto-seeding in test contexts, fixing the "empty DB" integration test
- Update `createMcpClient` test helper to accept custom env vars

## Root Cause
The Dockerfile builder stage was missing Alpine build tools (`python3 make g++`). These were only installed in the production stage, but the builder stage also runs `npm ci` which compiles `better-sqlite3` native modules. Without the tools, the builder's `npm ci` fails with compilation errors, breaking Railway deploys.

## Changes
- `Dockerfile`: Add `RUN apk add --no-cache python3 make g++` before `npm ci` in builder stage
- `src/server.ts`: Guard `autoSeed()` behind `NO_AUTO_SEED` env var check
- `tests/integration/mcp-stdio.test.ts`: Pass `NO_AUTO_SEED=1` in the empty-DB test

## Test plan
- [ ] Verify TypeScript build succeeds (`npm run build`)
- [ ] Verify Railway deploy succeeds after merge
- [ ] Verify `/health` endpoint responds after deploy

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)