### PR TITLE
feat(#153): add stdio transport entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "main": "dist/server.js",
   "bin": {
-    "agentic-ads": "dist/server.js"
+    "agentic-ads": "dist/stdio.js",
+    "agentic-ads-server": "dist/server.js"
   },
   "scripts": {
     "build": "tsc",

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+// Dedicated stdio entrypoint for MCP clients (Claude Desktop, Cursor, etc.)
+// Forces stdio transport mode so registries like Glama.ai index this as an MCP server.
+
+if (!process.argv.includes('--stdio')) {
+  process.argv.push('--stdio');
+}
+
+await import('./server.js');


### PR DESCRIPTION
## Summary
- Adds `src/stdio.ts` — dedicated stdio entrypoint that forces `--stdio` mode, so MCP registries (Glama.ai, awesome-mcp-servers) index us as a **server**, not just a connector
- Updates `bin` field: `agentic-ads` now points to `dist/stdio.js` (stdio by default for `npx` usage), `agentic-ads-server` points to `dist/server.js` (HTTP)
- **No changes to existing HTTP transport** — both coexist

## Context
awesome-mcp-servers PR #2454 is blocked because we only have a connector listing. This unblocks it.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx tsc` builds `dist/stdio.js` with shebang
- [x] Non-SQLite tests pass (SQLite tests fail due to pre-existing Node version mismatch in local env)
- [ ] `npx agentic-ads` starts stdio server
- [ ] `npx agentic-ads-server --http` starts HTTP server

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)